### PR TITLE
Add JSON feedback request with CORS script

### DIFF
--- a/apps-script/README.md
+++ b/apps-script/README.md
@@ -1,0 +1,7 @@
+# Google Apps Script for Feedback
+
+Deploy this script as a Web App with access "Anyone". It accepts JSON
+payload from the feedback form and responds with CORS headers.
+
+Place the code from `feedback.gs` into your Apps Script project.
+

--- a/apps-script/feedback.gs
+++ b/apps-script/feedback.gs
@@ -1,0 +1,23 @@
+function doPost(e) {
+  // Parse JSON payload
+  var data = {};
+  if (e.postData && e.postData.type === 'application/json') {
+    data = JSON.parse(e.postData.contents);
+  }
+
+  // TODO: зберегти data.email та data.message у Google Таблицю
+
+  return ContentService.createTextOutput(JSON.stringify({status: 'ok'}))
+    .setMimeType(ContentService.MimeType.JSON)
+    .setHeader('Access-Control-Allow-Origin', '*')
+    .setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS')
+    .setHeader('Access-Control-Allow-Headers', 'Content-Type');
+}
+
+function doGet() {
+  return ContentService.createTextOutput('ok')
+    .setMimeType(ContentService.MimeType.TEXT)
+    .setHeader('Access-Control-Allow-Origin', '*')
+    .setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS')
+    .setHeader('Access-Control-Allow-Headers', 'Content-Type');
+}

--- a/logic/feedback.js
+++ b/logic/feedback.js
@@ -29,14 +29,14 @@ function closeFeedback() {
   if (wrapper) wrapper.style.display = 'none';
 }
 
-// Сабміт форми: simple request без pre‑flight CORS
+// Сабміт форми: JSON із заголовком → викликає pre‑flight CORS
 async function submitFeedback(data) {
-  // "Simple request": без headers → браузер не робить pre‑flight, CORS не чіпляється
-  const body = new URLSearchParams(data); // email=a&message=b
-
   const res = await fetch(SCRIPT_URL, {
     method: 'POST',
-    body,            // application/x-www-form-urlencoded
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(data),
   });
   if (!res.ok) throw new Error('Помилка при надсиланні');
 }


### PR DESCRIPTION
## Summary
- switch feedback form submission to JSON
- add Google Apps Script example that includes CORS headers

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688a67cf7f60832f9f2cbd76dc186335